### PR TITLE
Adding some Convex auth

### DIFF
--- a/convex/auth.config.js
+++ b/convex/auth.config.js
@@ -1,0 +1,8 @@
+export default {
+	providers: [
+		{
+			domain: process.env.CLERK_ISSUER_URL,
+			applicationID: 'convex',
+		},
+	],
+};

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -14,14 +14,15 @@ import { MessageFields } from './schema';
 type Message = WithoutSystemFields<Doc<'messages'>>;
 
 export const get = query({
-	handler: async (ctx, { sender }: QueryArgs) => {
-		if (!sender) {
+	handler: async (ctx) => {
+		const identity = await ctx.auth.getUserIdentity();
+		if (!identity || !identity.phoneNumberVerified) {
 			return [];
 		}
 
 		const messages = await ctx.db
 			.query('messages')
-			.withIndex('by_sender', (q) => q.eq('sender', sender))
+			.withIndex('by_sender', (q) => q.eq('sender', identity.phoneNumber!))
 			.collect();
 
 		return messages;

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,6 +1,6 @@
 import {
+	ActionCtx,
 	httpAction,
-	internalAction,
 	internalMutation,
 	query,
 } from './_generated/server';
@@ -59,9 +59,7 @@ export const save = httpAction(async (ctx, req) => {
 
 	if (imageUrl) {
 		try {
-			msg.image = await ctx.runAction(internal.messages.storeImage, {
-				imageUrl,
-			});
+			msg.image = await storeImage(ctx, imageUrl);
 		} catch (err) {
 			console.error(`failed to store image (url: ${imageUrl})`);
 		}
@@ -81,19 +79,17 @@ export const saveMessage = internalMutation({
 	},
 });
 
-export const storeImage = internalAction(
-	async (ctx, { imageUrl }: { imageUrl: string }) => {
-		const res = await fetch(imageUrl);
+export const storeImage = async (ctx: ActionCtx, imageUrl: string) => {
+	const res = await fetch(imageUrl);
 
-		if (!res.ok) {
-			console.error(res);
-			return null;
-		}
+	if (!res.ok) {
+		console.error(res);
+		return null;
+	}
 
-		const blob = await res.blob();
-		const id = await ctx.storage.store(blob);
-		const url = await ctx.storage.getUrl(id);
+	const blob = await res.blob();
+	const id = await ctx.storage.store(blob);
+	const url = await ctx.storage.getUrl(id);
 
-		return { id, url };
-	},
-);
+	return { id, url };
+};

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -6,10 +6,12 @@ import {
 } from './_generated/server';
 import { Doc } from '../convex/_generated/dataModel';
 import { internal } from './_generated/api';
+import { v } from 'convex/values';
+import { WithoutSystemFields } from 'convex/server';
+import { MessageFields } from './schema';
 
 // let Convex define the type, leaving out generated fields
-type Message = Omit<Doc<'messages'>, '_id' | '_creationTime'>;
-type QueryArgs = Pick<Doc<'messages'>, 'sender'>;
+type Message = WithoutSystemFields<Doc<'messages'>>;
 
 export const get = query({
 	handler: async (ctx, { sender }: QueryArgs) => {
@@ -72,8 +74,11 @@ export const save = httpAction(async (ctx, req) => {
 	});
 });
 
-export const saveMessage = internalMutation(async (ctx, args: Message) => {
-	await ctx.db.insert('messages', args);
+export const saveMessage = internalMutation({
+	args: MessageFields,
+	handler: async (ctx, args) => {
+		await ctx.db.insert('messages', args);
+	},
 });
 
 export const storeImage = internalAction(

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -52,7 +52,7 @@ export const save = httpAction(async (ctx, req) => {
 		});
 	}
 
-	let msg: Message = {
+	const msg: Message = {
 		text,
 		sender,
 		image: null,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,16 +1,17 @@
 import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
+export const MessageFields = {
+	text: v.string(),
+	sender: v.string(),
+	image: v.union(
+		v.object({
+			id: v.string(),
+			url: v.union(v.string(), v.null()),
+		}),
+		v.null()
+	),
+};
 export default defineSchema({
-	messages: defineTable({
-		text: v.string(),
-		sender: v.string(),
-		image: v.union(
-			v.object({
-				id: v.string(),
-				url: v.union(v.string(), v.null()),
-			}),
-			v.null(),
-		),
-	}).index('by_sender', ['sender']),
+	messages: defineTable(MessageFields).index('by_sender', ['sender']),
 });

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,9 +1,5 @@
-import {
-	SignInButton,
-	SignUpButton,
-	SignedIn,
-	SignedOut,
-} from '@clerk/clerk-react';
+import { SignInButton, SignUpButton } from '@clerk/clerk-react';
+import { Authenticated, Unauthenticated } from 'convex/react';
 import { Messages } from './messages';
 import { Sidebar } from './sidebar';
 
@@ -12,7 +8,7 @@ import styles from './app.module.css';
 export const App = () => {
 	return (
 		<>
-			<SignedIn>
+			<Authenticated>
 				<main className={styles.container}>
 					<Sidebar />
 					<Messages />
@@ -26,8 +22,8 @@ export const App = () => {
 						<a href="https://lwj.dev/convex">try Convex</a>
 					</footer>
 				</main>
-			</SignedIn>
-			<SignedOut>
+			</Authenticated>
+			<Unauthenticated>
 				<main className={styles.signup}>
 					<h1>This demo requires a free account</h1>
 					<p>
@@ -50,7 +46,7 @@ export const App = () => {
 						</p>
 					</div>
 				</main>
-			</SignedOut>
+			</Unauthenticated>
 		</>
 	);
 };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,5 +1,5 @@
 import { SignInButton, SignUpButton } from '@clerk/clerk-react';
-import { Authenticated, Unauthenticated } from 'convex/react';
+import { Authenticated, Unauthenticated, AuthLoading } from 'convex/react';
 import { Messages } from './messages';
 import { Sidebar } from './sidebar';
 
@@ -23,6 +23,7 @@ export const App = () => {
 					</footer>
 				</main>
 			</Authenticated>
+			{/* <AuthLoading>...</AuthLoading> */}
 			<Unauthenticated>
 				<main className={styles.signup}>
 					<h1>This demo requires a free account</h1>

--- a/src/components/messages.tsx
+++ b/src/components/messages.tsx
@@ -1,4 +1,3 @@
-import { useUser } from '@clerk/clerk-react';
 import { useQuery } from 'convex/react';
 import { api } from '../../convex/_generated/api';
 
@@ -19,13 +18,8 @@ const Empty = () => {
 };
 
 export const Messages = () => {
-	const { user } = useUser();
-
-	// the user MUST provide a phone number to sign up, so know this is set
-	const sender = user!.primaryPhoneNumber!.phoneNumber;
-
 	// load all messages from the currently logged in user
-	const messages = useQuery(api.messages.get, { sender }) || [];
+	const messages = useQuery(api.messages.get) || [];
 
 	return (
 		<section className={styles.wrapper}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { ConvexProvider, ConvexReactClient } from 'convex/react';
-import { ClerkProvider } from '@clerk/clerk-react';
+import { ConvexProviderWithClerk } from 'convex/react-clerk';
+import { ConvexReactClient } from 'convex/react';
+import { ClerkProvider, useAuth } from '@clerk/clerk-react';
 import { App } from './components/app';
 
 import './styles/global.css';
@@ -11,9 +12,9 @@ const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 	<React.StrictMode>
 		<ClerkProvider publishableKey={import.meta.env.VITE_CLERK_PUBLISHABLE_KEY}>
-			<ConvexProvider client={convex}>
+			<ConvexProviderWithClerk client={convex} useAuth={useAuth}>
 				<App />
-			</ConvexProvider>
+			</ConvexProviderWithClerk>
 		</ClerkProvider>
-	</React.StrictMode>,
+	</React.StrictMode>
 );


### PR DESCRIPTION
Hey Jason!
I've added a few things:

1. Using Convex auth along with Clerk instead of trusting the client's "sender" parameter.
2. Storing the image with a function, not a `ctx.runAction` call: it can happen from `httpAction` 🎉
3. Using the schema fields for argument validation rather than just typescript types.

fyi you could also make the `Message` type by doing `Infer<typeof MessageFields>` with the new code, if you want to show that off (also imported from `convex/values`).

I also have a branch to do webhook verification, but I couldn't get it working quickly. It's there if you want to have a look, on my fork